### PR TITLE
Integrate URI.js

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -65,7 +65,7 @@ var Server = exports.Server = (function () {
             */
 
             value: function submitTransaction(transaction) {
-                var promise = axios.post(this.serverURL.path("transactions"), {
+                var promise = axios.post(URI(this.serverURL).path("transactions").toString(), {
                     tx: transaction.toEnvelope().toXDR().toString("hex")
                 }).then(function (response) {
                     return response.data;
@@ -249,7 +249,7 @@ var Server = exports.Server = (function () {
         },
         friendbot: {
             value: function friendbot(address) {
-                var url = this.serverURL.path("friendbot").addQuery("addr", address);
+                var url = URI(this.serverURL).path("friendbot").addQuery("addr", address);
                 return this._sendNormalRequest(url);
             }
         },
@@ -281,7 +281,7 @@ var Server = exports.Server = (function () {
                 var argArray = [type, id, resource].filter(function (x) {
                     return x !== null;
                 });
-                var url = this.serverURL.segment(argArray);
+                var url = URI(this.serverURL).segment(argArray);
                 if (opts) {
                     url = this._appendResourceCollectionConfiguration(url, opts);
                 }
@@ -353,10 +353,10 @@ var Server = exports.Server = (function () {
                 return {
                     records: json._embedded.records,
                     next: function next() {
-                        return self._sendNormalRequest(json._links.next.href).then(self._toCollectionPage.bind(self));
+                        return self._sendNormalRequest(URI(json._links.next.href)).then(self._toCollectionPage.bind(self));
                     },
                     prev: function prev() {
-                        return self._sendNormalRequest(json._links.prev.href).then(self._toCollectionPage.bind(self));
+                        return self._sendNormalRequest(URI(json._links.prev.href)).then(self._toCollectionPage.bind(self));
                     }
                 };
             }
@@ -376,9 +376,9 @@ var Server = exports.Server = (function () {
                     return function (opts) {
                         if (link.template) {
                             var template = URITemplate(link.href);
-                            return self._sendNormalRequest(template.expand(opts));
+                            return self._sendNormalRequest(URI(template.expand(opts)));
                         } else {
-                            return self._sendNormalRequest(link.href);
+                            return self._sendNormalRequest(URI(link.href));
                         }
                     };
                 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -22,7 +22,8 @@ var Account = _stellarBase.Account;
 
 var axios = require("axios");
 var toBluebird = require("bluebird").resolve;
-var UriTemplate = require("uritemplate");
+var URI = require("URIjs");
+var URITemplate = require("URIjs/src/URITemplate");
 
 var EventSource = typeof window === "undefined" ? require("eventsource") : window.EventSource;
 
@@ -47,9 +48,12 @@ var Server = exports.Server = (function () {
 
         _classCallCheck(this, Server);
 
-        this.protocol = config.secure ? "https://" : "http://";
+        this.protocol = config.secure ? "https" : "http";
         this.hostname = config.hostname || "localhost";
         this.port = config.port || 3000;
+        this.serverURL = URI({ protocol: this.protocol,
+            hostname: this.hostname,
+            port: this.port });
     }
 
     _createClass(Server, {
@@ -61,7 +65,7 @@ var Server = exports.Server = (function () {
             */
 
             value: function submitTransaction(transaction) {
-                var promise = axios.post(this.protocol + this.hostname + ":" + this.port + "/transactions", {
+                var promise = axios.post(this.serverURL.path("transactions"), {
                     tx: transaction.toEnvelope().toXDR().toString("hex")
                 }).then(function (response) {
                     return response.data;
@@ -245,8 +249,8 @@ var Server = exports.Server = (function () {
         },
         friendbot: {
             value: function friendbot(address) {
-                var endpoint = "/friendbot?addr=" + address;
-                return this._sendNormalRequest(endpoint);
+                var url = this.serverURL.path("friendbot").addQuery("addr", address);
+                return this._sendNormalRequest(url);
             }
         },
         _sendResourceRequest: {
@@ -260,36 +264,33 @@ var Server = exports.Server = (function () {
             */
 
             value: function _sendResourceRequest(type, id, resource, opts) {
-                var endpoint = this._buildEndpointPath(type, id, resource, opts);
+                var url = this._buildEndpointPath(type, id, resource, opts);
                 if (opts && opts.streaming) {
-                    return this._sendStreamingRequest(endpoint, opts.streaming);
+                    return this._sendStreamingRequest(url, opts.streaming);
                 } else {
-                    var promise = this._sendNormalRequest(endpoint).then(this._parseResponse.bind(this));
+                    var promise = this._sendNormalRequest(url).then(this._parseResponse.bind(this));
                     return promise;
                 }
             }
         },
         _buildEndpointPath: {
-            value: function _buildEndpointPath(type, id, subType, opts) {
-                var endpoint = "/" + type;
-                if (id) {
-                    endpoint += "/" + id;
+            value: function _buildEndpointPath(type, id, resource, opts) {
+                if (id && typeof id !== "string") {
+                    id = id.toString();
                 }
-                if (subType) {
-                    endpoint += "/" + subType;
-                }
+                var argArray = [type, id, resource].filter(function (x) {
+                    return x !== null;
+                });
+                var url = this.serverURL.segment(argArray);
                 if (opts) {
-                    endpoint = this._appendResourceCollectionConfiguration(endpoint, opts);
+                    url = this._appendResourceCollectionConfiguration(url, opts);
                 }
-                return endpoint;
+                return url;
             }
         },
         _sendNormalRequest: {
             value: function _sendNormalRequest(url) {
-                if (url.slice(0, 4) != "http") {
-                    url = this.protocol + this.hostname + ":" + this.port + url;
-                }
-                var promise = axios.get(url).then(function (response) {
+                var promise = axios.get(url.toString()).then(function (response) {
                     return response.data;
                 })["catch"](this._handleNetworkError);
                 return toBluebird(promise);
@@ -310,8 +311,8 @@ var Server = exports.Server = (function () {
             }
         },
         _sendStreamingRequest: {
-            value: function _sendStreamingRequest(endpoint, streaming) {
-                var es = new EventSource(this.protocol + this.hostname + ":" + this.port + endpoint);
+            value: function _sendStreamingRequest(url, streaming) {
+                var es = new EventSource(url.toString());
                 es.onmessage = function (message) {
                     var result = message.data ? JSON.parse(message.data) : message;
                     streaming.onmessage(result);
@@ -321,18 +322,17 @@ var Server = exports.Server = (function () {
             }
         },
         _appendResourceCollectionConfiguration: {
-            value: function _appendResourceCollectionConfiguration(endpoint, opts) {
-                endpoint = endpoint + "?";
+            value: function _appendResourceCollectionConfiguration(url, opts) {
                 if (opts.after) {
-                    endpoint += "after=" + opts.after;
+                    url.addQuery("after", opts.after);
                 }
                 if (opts.limit) {
-                    endpoint += "&limit=" + opts.limit;
+                    url.addQuery("limit", opts.limit);
                 }
                 if (opts.order) {
-                    endpoint += "&order=" + opts.order;
+                    url.addQuery("order", opts.order);
                 }
-                return endpoint;
+                return url;
             }
         },
         _parseResponse: {
@@ -353,10 +353,10 @@ var Server = exports.Server = (function () {
                 return {
                     records: json._embedded.records,
                     next: function next() {
-                        return self._sendLinkRequest(json._links.next.href).then(self._toCollectionPage.bind(self));
+                        return self._sendNormalRequest(json._links.next.href).then(self._toCollectionPage.bind(self));
                     },
                     prev: function prev() {
-                        return self._sendLinkRequest(json._links.prev.href).then(self._toCollectionPage.bind(self));
+                        return self._sendNormalRequest(json._links.prev.href).then(self._toCollectionPage.bind(self));
                     }
                 };
             }
@@ -375,8 +375,8 @@ var Server = exports.Server = (function () {
                 var linkFn = function linkFn(link) {
                     return function (opts) {
                         if (link.template) {
-                            var template = UriTemplate(link.href);
-                            return self._sendNormalRequest(_template.expand(opts));
+                            var template = URITemplate(link.href);
+                            return self._sendNormalRequest(template.expand(opts));
                         } else {
                             return self._sendNormalRequest(link.href);
                         }

--- a/package.json
+++ b/package.json
@@ -53,13 +53,13 @@
     "webpack": "^1.7.3"
   },
   "dependencies": {
+    "URIjs": "^1.16.0",
     "axios": "^0.5.4",
     "bluebird": "^2.9.25",
     "eventsource": "^0.1.6",
     "jsdoc": "jsdoc3/jsdoc#master",
     "lodash": "^3.6.0",
     "stellar-base": "0.3.1",
-    "superagent": "^1.1.0",
-    "uritemplate": "^0.3.4"
+    "superagent": "^1.1.0"
   }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -5,7 +5,8 @@ import {xdr, Account} from "stellar-base";
 
 let axios = require("axios");
 let toBluebird = require("bluebird").resolve;
-let UriTemplate = require("uritemplate");
+let URI = require("URIjs");
+let URITemplate = require('URIjs/src/URITemplate');
 
 var EventSource = (typeof window === 'undefined') ? require('eventsource') : window.EventSource;
 
@@ -24,9 +25,12 @@ export class Server {
     * @param {number}   [config.port] - Horizon port, defaults to 3000.
     */
     constructor(config={}) {
-        this.protocol = config.secure ? "https://" : "http://";
+        this.protocol = config.secure ? "https" : "http";
         this.hostname = config.hostname || "localhost";
         this.port = config.port || 3000;
+        this.serverURL = URI({ protocol: this.protocol, 
+                             hostname: this.hostname,
+                             port: this.port });
     }
 
     /**
@@ -34,7 +38,7 @@ export class Server {
     * @param {Transaction} transaction - The transaction to submit.
     */
     submitTransaction(transaction) {
-        var promise = axios.post(this.protocol + this.hostname + ":" + this.port + '/transactions', {
+        var promise = axios.post(this.serverURL.path('transactions'), {
                 tx: transaction.toEnvelope().toXDR().toString("hex")
             })
             .then(function(response) {
@@ -202,8 +206,8 @@ export class Server {
     }
 
     friendbot(address) {
-        var endpoint = "/friendbot?addr=" + address;
-        return this._sendNormalRequest(endpoint);
+        var url = this.serverURL.path("friendbot").addQuery("addr", address);
+        return this._sendNormalRequest(url);
     }
 
     /**
@@ -214,35 +218,30 @@ export class Server {
     * @param {string} type - {"accounts", "ledgers", "transactions"}
     */
     _sendResourceRequest(type, id, resource, opts) {
-        var endpoint = this._buildEndpointPath(type, id, resource, opts);
+        var url = this._buildEndpointPath(type, id, resource, opts);
         if (opts && opts.streaming) {
-            return this._sendStreamingRequest(endpoint, opts.streaming);
+            return this._sendStreamingRequest(url, opts.streaming);
         } else {
-            var promise = this._sendNormalRequest(endpoint)
+            var promise = this._sendNormalRequest(url)
                 .then(this._parseResponse.bind(this));
             return promise;
         }
     }
 
-    _buildEndpointPath(type, id, subType, opts) {
-        let endpoint = "/" + type;
-        if (id) {
-            endpoint += "/" + id;
+    _buildEndpointPath(type, id, resource, opts) {
+        if (id && typeof id !== 'string') {
+            id = id.toString();
         }
-        if (subType) {
-            endpoint += "/" +subType;
-        }
+        let argArray = [type, id, resource].filter(function(x) { return x !== null; });
+        let url = this.serverURL.segment(argArray);
         if (opts) {
-            endpoint = this._appendResourceCollectionConfiguration(endpoint, opts);
+            url = this._appendResourceCollectionConfiguration(url, opts);
         }
-        return endpoint;
+        return url;
     }
 
     _sendNormalRequest(url) {
-        if (url.slice(0,4) != "http") {
-            url = this.protocol + this.hostname + ":" + this.port + url;
-        }
-        var promise = axios.get(url)
+        var promise = axios.get(url.toString())
             .then(function (response) {
                 return response.data;
             })
@@ -263,8 +262,8 @@ export class Server {
         }
     }
 
-    _sendStreamingRequest(endpoint, streaming) {
-        var es = new EventSource(this.protocol + this.hostname + ":" + this.port + endpoint);
+    _sendStreamingRequest(url, streaming) {
+        var es = new EventSource(url.toString());
         es.onmessage = function (message) {
             var result = message.data ? JSON.parse(message.data) : message;
             streaming.onmessage(result);
@@ -273,18 +272,17 @@ export class Server {
         return es;
     }
 
-    _appendResourceCollectionConfiguration(endpoint, opts) {
-        endpoint = endpoint + "?";
+    _appendResourceCollectionConfiguration(url, opts) {
         if (opts.after) {
-            endpoint += "after=" + opts.after;
+            url.addQuery("after", opts.after); 
         }
         if (opts.limit) {
-            endpoint += "&limit=" + opts.limit;
+            url.addQuery("limit", opts.limit);
         }
         if (opts.order) {
-            endpoint += "&order=" + opts.order;
+            url.addQuery("order", opts.order);
         }
-        return endpoint;
+        return url;
     }
 
     _parseResponse(json) {
@@ -324,8 +322,8 @@ export class Server {
         var linkFn = function (link) {
             return function (opts) {
                 if (link.template) {
-                    let template = UriTemplate(link.href);
-                    return self._sendNormalRequest(_template.expand(opts));
+                    let template = URITemplate(link.href);
+                    return self._sendNormalRequest(template.expand(opts));
                 } else {
                     return self._sendNormalRequest(link.href);
                 }

--- a/src/server.js
+++ b/src/server.js
@@ -38,7 +38,7 @@ export class Server {
     * @param {Transaction} transaction - The transaction to submit.
     */
     submitTransaction(transaction) {
-        var promise = axios.post(this.serverURL.path('transactions'), {
+        var promise = axios.post(URI(this.serverURL).path('transactions').toString(), {
                 tx: transaction.toEnvelope().toXDR().toString("hex")
             })
             .then(function(response) {
@@ -206,7 +206,7 @@ export class Server {
     }
 
     friendbot(address) {
-        var url = this.serverURL.path("friendbot").addQuery("addr", address);
+        var url = URI(this.serverURL).path("friendbot").addQuery("addr", address);
         return this._sendNormalRequest(url);
     }
 
@@ -233,7 +233,7 @@ export class Server {
             id = id.toString();
         }
         let argArray = [type, id, resource].filter(function(x) { return x !== null; });
-        let url = this.serverURL.segment(argArray);
+        let url = URI(this.serverURL).segment(argArray);
         if (opts) {
             url = this._appendResourceCollectionConfiguration(url, opts);
         }
@@ -301,11 +301,11 @@ export class Server {
         return {
             records: json._embedded.records,
             next: function () {
-                return self._sendNormalRequest(json._links.next.href)
+                return self._sendNormalRequest(URI(json._links.next.href))
                     .then(self._toCollectionPage.bind(self));
             },
             prev: function () {
-                return self._sendNormalRequest(json._links.prev.href)
+                return self._sendNormalRequest(URI(json._links.prev.href))
                     .then(self._toCollectionPage.bind(self));
             }
         };
@@ -323,9 +323,9 @@ export class Server {
             return function (opts) {
                 if (link.template) {
                     let template = URITemplate(link.href);
-                    return self._sendNormalRequest(template.expand(opts));
+                    return self._sendNormalRequest(URI(template.expand(opts)));
                 } else {
-                    return self._sendNormalRequest(link.href);
+                    return self._sendNormalRequest(URI(link.href));
                 }
             };
         };

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -64,7 +64,7 @@ describe("server.js tests", function () {
           // instruct the dev server to except the correct request
           return this.setFixtures({
             request: url,
-            response: {status: 200, body: makeFakePage(url)}
+            response: {status: 200, body: makeFakePage('http://localhost:1337' + url)}
           }).then(function () { done(); });
         });
 


### PR DESCRIPTION
Resolves #24 

There were many places where we built up URLs manually by string manipulation.  I used URI.js to do so instead and passed around URI objects instead of string path fragments (e.g., 'ledgers/1/transactions').